### PR TITLE
Expand and clarify project roles and personas in process documentation

### DIFF
--- a/docs/octoacme-roles-and-personas.md
+++ b/docs/octoacme-roles-and-personas.md
@@ -74,6 +74,52 @@ Project Managers coordinate delivery activities, manage schedules, risks, and co
 - Coordination via project boards and meeting facilitation
 
 ---
+## New/Refined Roles
+
+### Release Manager
+**Responsibilities**:
+- Coordinate release readiness
+- Liaise between engineering, QA, and customer-facing teams
+- Ensure release documentation and sign-off
+
+**Interactions**:
+- Works with Project Manager, QA Lead, Product Owner
+
+### Communications Lead
+**Responsibilities**:
+- Owns project communications (internal/external)
+- Sends change notices, project updates
+- Keeps all stakeholders informed
+
+**Interactions**:
+- Works with Project Manager, all team members
+
+### Project Auditor
+**Responsibilities**:
+- Audits milestones, deliverables, compliance
+- Reports findings for continuous improvement
+
+**Interactions**:
+- Coordinates with all process owners
+
+### Customer Success Partner
+**Responsibilities**:
+- Brings customer needs to the team
+- Clarifies requirements and feedback
+- Ensures post-release satisfaction
+
+**Interactions**:
+- Connects Product Owner, Engineering, Customer
+
+<!-- If missing, add a checklist template -->
+---
+
+## Onboarding Checklist for New Project Personas
+
+- [ ] Review assigned responsibilities
+- [ ] Meet all primary role contacts
+- [ ] Understand communications cadence
+- [ ] Confirm escalation/decision paths
 
 ## How these personas are used in the exercise
 - Use these persona definitions to frame scenarios and sample interactions in the Skills Exercise.


### PR DESCRIPTION
This PR implements improvements based on [issue #4](https://github.com/divyasirisala/skills-scale-institutional-knowledge-using-copilot-spaces/issues/4), addressing gaps in defined roles and responsibilities within project management process documentation.
Key changes:

Added new personas: Release Manager, Communications Lead, Project Auditor, Customer Success Partner
For each, described responsibilities and key interactions with existing roles
Clarified existing role responsibilities
Ensured all changes are in docs/octoacme-roles-and-personas.md
Added checklist template for onboarding new roles (in docs/ if lacking)